### PR TITLE
Fix: Neat needs to be installed in _sass directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ cd VeChain-New-Website
 bundle install
 
 # Install latest version of Neat SCSS grid
+# CD in _sass directory
 neat install
 ```
 


### PR DESCRIPTION
# Why?

README says to install neat in root directory. It should be in the `_sass` directory.

# What Changed?

Updated README instructions. 
